### PR TITLE
Fix build errors  for dev-2025-09

### DIFF
--- a/errors/errors.odin
+++ b/errors/errors.odin
@@ -1,3 +1,4 @@
+#+feature global-context
 /*
 This file is part of runic.
 

--- a/runic/rune.odin
+++ b/runic/rune.odin
@@ -1454,7 +1454,7 @@ parse_rune :: proc(
                                 )
                                 errors.wrap(mem_err) or_return
 
-                                d_map[d_key] = strconv.append_int(
+                                d_map[d_key] = strconv.write_int(
                                     buf[:],
                                     d_v,
                                     10,
@@ -1467,7 +1467,7 @@ parse_rune :: proc(
                                 )
                                 errors.wrap(mem_err) or_return
 
-                                d_map[d_key] = strconv.append_float(
+                                d_map[d_key] = strconv.write_float(
                                     buf[:],
                                     d_v,
                                     'f',


### PR DESCRIPTION
I am running off of odin master so maybe you don't care, but when I tried to build 2 functions have been deprecated from `core:strconv` as well as the addition of the `#+feature global-context` flag